### PR TITLE
we must not use  disk_cache 

### DIFF
--- a/scripts/addons/parallel_render.py
+++ b/scripts/addons/parallel_render.py
@@ -754,6 +754,8 @@ def render():
 
             outfile = bpy.context.scene.render.frame_path()
 
+            bpy.context.preferences.system.use_sequencer_disk_cache=False
+
             def _update_progress(_ignored):
                 send_stats(bpy.context.scene.frame_current)
 


### PR DESCRIPTION
During my usage , many instances crashed , i was using disk cache .

the setting is here => Edit / Preferences / system / video sequencer / use_disk_cache 

This was not design to be access by multiple process